### PR TITLE
Adding code test coverage metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "typecheck": "tsc",
     "test": "node --experimental-strip-types --test test/**/*.test.ts",
-    "test:watch": "node --experimental-strip-types --test --watch test/**/*.test.ts"
+    "test:watch": "node --experimental-strip-types --test --watch test/**/*.test.ts",
+    "test:coverage": "node --experimental-strip-types --experimental-test-coverage --test test/**/*.test.ts"
   },
   "keywords": [
     "mongodb",


### PR DESCRIPTION
Uses --experimental-test-coverage flag for native code coverage reporting without additional dependencies.