### PR TITLE
Add pre-commit lint and type checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run precommit

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.0.3",
+        "husky": "^9.1.7",
         "mongodb": "^6.12.0",
         "typescript": "^5.7.2"
       },
@@ -62,6 +63,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/memory-pager": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
+    "precommit": "npm run typecheck",
     "typecheck": "tsc",
     "test": "node --experimental-strip-types --test test/**/*.test.ts",
     "test:watch": "node --experimental-strip-types --test --watch test/**/*.test.ts",
-    "test:coverage": "node --experimental-strip-types --experimental-test-coverage --test test/**/*.test.ts"
+    "test:coverage": "node --experimental-strip-types --experimental-test-coverage --test test/**/*.test.ts",
+    "prepare": "husky"
   },
   "keywords": [
     "mongodb",
@@ -22,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^25.0.3",
+    "husky": "^9.1.7",
     "mongodb": "^6.12.0",
     "typescript": "^5.7.2"
   },


### PR DESCRIPTION
- Install husky for git hooks management
- Add precommit script that runs typecheck
- Configure pre-commit hook to enforce type checking before commits