### PR TITLE
Configure package.json for MongoDB package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-12-24
+
+### Added
+
+- Initial release of MangoDB
+- `MangoDBClient` for file-based MongoDB-compatible storage
+- `MangoDBDb` for database operations
+- `MangoDBCollection` with CRUD operations:
+  - `insertOne`, `insertMany`
+  - `findOne`, `find` with cursor support
+  - `updateOne`, `updateMany`
+  - `deleteOne`, `deleteMany`
+  - `replaceOne`
+  - `countDocuments`, `estimatedDocumentCount`
+  - `distinct`
+- Query operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, `$not`, `$nor`, `$exists`, `$type`, `$regex`, `$elemMatch`, `$all`, `$size`, `$mod`, `$text`
+- Update operators: `$set`, `$unset`, `$inc`, `$push`, `$pull`, `$addToSet`, `$pop`, `$rename`, `$min`, `$max`, `$mul`, `$currentDate`
+- Aggregation pipeline support with stages: `$match`, `$project`, `$sort`, `$limit`, `$skip`, `$count`, `$unwind`, `$group`, `$lookup`, `$addFields`, `$set`, `$unset`, `$replaceRoot`, `$replaceWith`, `$sample`, `$sortByCount`, `$facet`
+- Index support: single-field, compound, unique, sparse, text indexes
+- Cursor operations: `toArray`, `forEach`, `map`, `limit`, `skip`, `sort`, `project`
+- Full TypeScript support with type definitions

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ MangoDB lets you develop and test locally using only the filesystem, then deploy
 
 See [ROADMAP.md](./ROADMAP.md) for implementation phases and [PROGRESS.md](./PROGRESS.md) for current status.
 
+## Installation
+
+```bash
+npm install @jkershaw/mangodb
+```
+
 ## Usage
 
 ### With MangoDB (local development/testing)
 
 ```typescript
-import { MangoDBClient } from 'mangodb';
+import { MangoDBClient } from '@jkershaw/mangodb';
 
 const client = new MangoDBClient('./data');
 await client.connect();
@@ -57,7 +63,7 @@ await client.close();
 
 ```typescript
 import { MongoClient } from 'mongodb';
-import { MangoDBClient } from 'mangodb';
+import { MangoDBClient } from '@jkershaw/mangodb';
 
 const client = process.env.MONGODB_URI
   ? new MongoClient(process.env.MONGODB_URI)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mangodb",
+  "name": "@jkershaw/mangodb",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mangodb",
+      "name": "@jkershaw/mangodb",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,27 +1,50 @@
 {
-  "name": "mangodb",
+  "name": "@jkershaw/mangodb",
   "version": "0.1.0",
   "description": "File-based MongoDB drop-in replacement for TypeScript/Node.js. SQLite is to SQL as MangoDB is to MongoDB.",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
     "precommit": "npm run typecheck",
     "typecheck": "tsc",
     "test": "node --experimental-strip-types --test test/**/*.test.ts",
     "test:watch": "node --experimental-strip-types --test --watch test/**/*.test.ts",
     "test:coverage": "node --experimental-strip-types --experimental-test-coverage --test test/**/*.test.ts",
+    "prepublishOnly": "npm run clean && npm run build && npm test",
     "prepare": "husky"
   },
   "keywords": [
     "mongodb",
     "database",
+    "embedded",
     "file-based",
     "drop-in",
+    "nosql",
     "local",
     "testing"
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JKershaw/mangodb.git"
+  },
+  "bugs": {
+    "url": "https://github.com/JKershaw/mangodb/issues"
+  },
+  "homepage": "https://github.com/JKershaw/mangodb#readme",
   "dependencies": {
     "bson": "^6.10.4"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}


### PR DESCRIPTION
- Rename package to @jkershaw/mangodb (scoped)
- Add main, types, exports, and files fields for npm
- Add repository, bugs, and homepage links
- Add build and prepublishOnly scripts
- Create tsconfig.build.json for TypeScript compilation
- Update README with scoped package install/import examples
- Add CHANGELOG.md for v0.1.0 initial release