### PR TITLE
Make class names more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of MangoDB
-- `MangoDBClient` for file-based MongoDB-compatible storage
-- `MangoDBDb` for database operations
-- `MangoDBCollection` with CRUD operations:
+- `MangoClient` for file-based MongoDB-compatible storage
+- `MangoDb` for database operations
+- `MangoCollection` with CRUD operations:
   - `insertOne`, `insertMany`
   - `findOne`, `find` with cursor support
   - `updateOne`, `updateMany`

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ npm install @jkershaw/mangodb
 ### With MangoDB (local development/testing)
 
 ```typescript
-import { MangoDBClient } from '@jkershaw/mangodb';
+import { MangoClient } from '@jkershaw/mangodb';
 
-const client = new MangoDBClient('./data');
+const client = new MangoClient('./data');
 await client.connect();
 
 const db = client.db('myapp');
@@ -63,11 +63,11 @@ await client.close();
 
 ```typescript
 import { MongoClient } from 'mongodb';
-import { MangoDBClient } from '@jkershaw/mangodb';
+import { MangoClient } from '@jkershaw/mangodb';
 
 const client = process.env.MONGODB_URI
   ? new MongoClient(process.env.MONGODB_URI)
-  : new MangoDBClient('./data');
+  : new MangoClient('./data');
 
 await client.connect();
 // ... rest of your code works identically

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,31 +1,31 @@
-import { MangoDBDb } from "./db.ts";
+import { MangoDb } from "./db.ts";
 import { mkdir } from "node:fs/promises";
 
 /**
- * MangoDBClient is the entry point for using MangoDB.
+ * MangoClient is the entry point for using MangoDB.
  * It mirrors the MongoClient API from the official MongoDB driver,
  * providing a MongoDB-compatible client interface backed by file storage.
  *
  * @example
  * ```typescript
- * const client = new MangoDBClient('./data');
+ * const client = new MangoClient('./data');
  * await client.connect();
  * const db = client.db('myDatabase');
  * await client.close();
  * ```
  */
-export class MangoDBClient {
+export class MangoClient {
   private readonly dataDir: string;
   private connected = false;
-  private databases = new Map<string, MangoDBDb>();
+  private databases = new Map<string, MangoDb>();
 
   /**
-   * Create a new MangoDBClient.
+   * Create a new MangoClient.
    * @param dataDir - Directory where data will be stored
    *
    * @example
    * ```typescript
-   * const client = new MangoDBClient('./data');
+   * const client = new MangoClient('./data');
    * ```
    */
   constructor(dataDir: string) {
@@ -40,7 +40,7 @@ export class MangoDBClient {
    *
    * @example
    * ```typescript
-   * const client = new MangoDBClient('./data');
+   * const client = new MangoClient('./data');
    * await client.connect();
    * ```
    */
@@ -69,7 +69,7 @@ export class MangoDBClient {
    * Database instances are cached and reused for the same name.
    *
    * @param name - Database name
-   * @returns A MangoDBDb instance
+   * @returns A MangoDb instance
    *
    * @example
    * ```typescript
@@ -77,9 +77,9 @@ export class MangoDBClient {
    * const collection = db.collection('users');
    * ```
    */
-  db(name: string): MangoDBDb {
+  db(name: string): MangoDb {
     if (!this.databases.has(name)) {
-      this.databases.set(name, new MangoDBDb(this.dataDir, name));
+      this.databases.set(name, new MangoDb(this.dataDir, name));
     }
     return this.databases.get(name)!;
   }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -61,7 +61,7 @@ export class IndexCursor {
 }
 
 /**
- * MangoDBCursor represents a cursor over query results.
+ * MangoCursor represents a cursor over query results.
  * It mirrors the Cursor API from the official MongoDB driver, providing chainable methods
  * for sorting, limiting, skipping, and projecting query results.
  *
@@ -77,7 +77,7 @@ export class IndexCursor {
  *   .toArray();
  * ```
  */
-export class MangoDBCursor<T extends Document = Document> {
+export class MangoCursor<T extends Document = Document> {
   private readonly fetchDocuments: () => Promise<T[]>;
   private sortSpec: SortSpec | null = null;
   private limitValue: number | null = null;
@@ -87,7 +87,7 @@ export class MangoDBCursor<T extends Document = Document> {
   private readonly hintValidator: HintValidator | null = null;
 
   /**
-   * Creates a new MangoDBCursor instance.
+   * Creates a new MangoCursor instance.
    *
    * @param fetchDocuments - Function that returns a promise resolving to an array of documents
    * @param projection - Optional projection specification to apply to all results
@@ -120,7 +120,7 @@ export class MangoDBCursor<T extends Document = Document> {
    * cursor.sort({ createdAt: -1 });
    * ```
    */
-  sort(spec: SortSpec): MangoDBCursor<T> {
+  sort(spec: SortSpec): MangoCursor<T> {
     this.sortSpec = spec;
     return this;
   }
@@ -146,7 +146,7 @@ export class MangoDBCursor<T extends Document = Document> {
    * cursor.limit(-5); // Same as limit(5)
    * ```
    */
-  limit(n: number): MangoDBCursor<T> {
+  limit(n: number): MangoCursor<T> {
     const absN = Math.abs(n);
     // limit(0) means no limit in MongoDB
     this.limitValue = absN === 0 ? null : absN;
@@ -173,7 +173,7 @@ export class MangoDBCursor<T extends Document = Document> {
    * cursor.skip((page - 1) * pageSize).limit(pageSize);
    * ```
    */
-  skip(n: number): MangoDBCursor<T> {
+  skip(n: number): MangoCursor<T> {
     if (n < 0) {
       throw new Error("Skip value must be non-negative");
     }
@@ -202,7 +202,7 @@ export class MangoDBCursor<T extends Document = Document> {
    * cursor.hint({ $natural: -1 }); // Reverse scan
    * ```
    */
-  hint(indexHint: string | Record<string, unknown>): MangoDBCursor<T> {
+  hint(indexHint: string | Record<string, unknown>): MangoCursor<T> {
     this.hintSpec = indexHint;
     return this;
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-import { MangoDBCollection } from "./collection.ts";
+import { MangoCollection } from "./collection.ts";
 import { rm, readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { matchesFilter } from "./query-matcher.ts";
@@ -11,26 +11,26 @@ import type {
 } from "./types.ts";
 
 /**
- * MangoDBDb represents a database in MangoDB.
+ * MangoDb represents a database in MangoDB.
  * It mirrors the Db API from the official MongoDB driver,
  * providing methods to work with collections and manage the database.
  *
  * @example
  * ```typescript
- * const client = new MangoDBClient('./data');
+ * const client = new MangoClient('./data');
  * await client.connect();
  * const db = client.db('myDatabase');
  * const collection = db.collection('users');
  * ```
  */
-export class MangoDBDb {
+export class MangoDb {
   private readonly dataDir: string;
   private readonly name: string;
-  private collections = new Map<string, MangoDBCollection<Document>>();
+  private collections = new Map<string, MangoCollection<Document>>();
 
   /**
-   * Create a new MangoDBDb instance.
-   * Note: Typically you don't create this directly; use MangoDBClient.db() instead.
+   * Create a new MangoDb instance.
+   * Note: Typically you don't create this directly; use MangoClient.db() instead.
    *
    * @param dataDir - Base directory for storing database files
    * @param name - Database name
@@ -52,7 +52,7 @@ export class MangoDBDb {
    * The generic type parameter T allows for typed document operations.
    *
    * @param name - Collection name
-   * @returns A MangoDBCollection instance typed to T
+   * @returns A MangoCollection instance typed to T
    *
    * @example
    * ```typescript
@@ -68,14 +68,14 @@ export class MangoDBDb {
    * const typedUsers = db.collection<User>('users');
    * ```
    */
-  collection<T extends Document = Document>(name: string): MangoDBCollection<T> {
+  collection<T extends Document = Document>(name: string): MangoCollection<T> {
     if (!this.collections.has(name)) {
       this.collections.set(
         name,
-        new MangoDBCollection<Document>(this.dataDir, this.name, name)
+        new MangoCollection<Document>(this.dataDir, this.name, name)
       );
     }
-    return this.collections.get(name)! as MangoDBCollection<T>;
+    return this.collections.get(name)! as MangoCollection<T>;
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,14 +14,14 @@ import type { IndexKeySpec } from "./types.ts";
  *   await collection.insertOne({ email: 'user@example.com' });
  *   await collection.insertOne({ email: 'user@example.com' }); // Duplicate!
  * } catch (err) {
- *   if (err instanceof MongoDuplicateKeyError) {
+ *   if (err instanceof DuplicateKeyError) {
  *     console.log('Duplicate key error:', err.keyValue);
  *     console.log('Index pattern:', err.keyPattern);
  *   }
  * }
  * ```
  */
-export class MongoDuplicateKeyError extends Error {
+export class DuplicateKeyError extends Error {
   /** MongoDB error code for duplicate key */
   readonly code = 11000;
 
@@ -32,7 +32,7 @@ export class MongoDuplicateKeyError extends Error {
   readonly keyValue: Record<string, unknown>;
 
   /**
-   * Create a new MongoDuplicateKeyError.
+   * Create a new DuplicateKeyError.
    *
    * @param db - Database name where the error occurred
    * @param collection - Collection name where the error occurred
@@ -53,7 +53,7 @@ export class MongoDuplicateKeyError extends Error {
     super(
       `E11000 duplicate key error collection: ${db}.${collection} index: ${indexName} dup key: { ${keyStr} }`
     );
-    this.name = "MongoDuplicateKeyError";
+    this.name = "DuplicateKeyError";
     this.keyPattern = keyPattern;
     this.keyValue = keyValue;
   }

--- a/src/index-manager.ts
+++ b/src/index-manager.ts
@@ -5,7 +5,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { Document, IndexKeySpec, IndexInfo, CreateIndexOptions } from "./types.ts";
 import { getValueByPath } from "./document-utils.ts";
-import { MongoDuplicateKeyError, IndexNotFoundError, CannotDropIdIndexError, InvalidIndexOptionsError } from "./errors.ts";
+import { DuplicateKeyError, IndexNotFoundError, CannotDropIdIndexError, InvalidIndexOptionsError } from "./errors.ts";
 import { matchesFilter } from "./query-matcher.ts";
 
 /**
@@ -325,7 +325,7 @@ export class IndexManager {
    * @param docs - Documents to be inserted or updated
    * @param existingDocs - All existing documents in the collection
    * @param excludeIds - Document IDs to exclude from constraint checking (for updates)
-   * @throws MongoDuplicateKeyError if a unique constraint would be violated
+   * @throws DuplicateKeyError if a unique constraint would be violated
    */
   async checkUniqueConstraints<T extends Document>(
     docs: T[],
@@ -390,7 +390,7 @@ export class IndexManager {
         const valueMap = existingValues.get(idx.name)!;
 
         if (valueMap.has(keyStr)) {
-          throw new MongoDuplicateKeyError(
+          throw new DuplicateKeyError(
             this.dbName,
             this.collectionName,
             idx.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-export { MangoDBClient } from "./client.ts";
-export { MangoDBDb } from "./db.ts";
-export { MangoDBCollection } from "./collection.ts";
+export { MangoClient } from "./client.ts";
+export { MangoDb } from "./db.ts";
+export { MangoCollection } from "./collection.ts";
 export type { IndexKeySpec, CreateIndexOptions, IndexInfo } from "./collection.ts";
-export { MangoDBCursor, IndexCursor } from "./cursor.ts";
+export { MangoCursor, IndexCursor } from "./cursor.ts";
 export { AggregationCursor } from "./aggregation/index.ts";
 export {
-  MongoDuplicateKeyError,
+  DuplicateKeyError,
   IndexNotFoundError,
   CannotDropIdIndexError,
   TextIndexRequiredError,

--- a/test/test-harness.ts
+++ b/test/test-harness.ts
@@ -9,7 +9,7 @@
  */
 
 import { MongoClient } from "mongodb";
-import { MangoDBClient } from "../src/index.ts";
+import { MangoClient } from "../src/index.ts";
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 
@@ -272,7 +272,7 @@ export async function createTestClient(): Promise<{
     };
   } else {
     const dataDir = `/tmp/mangodb_test_${randomUUID()}`;
-    const client = new MangoDBClient(dataDir);
+    const client = new MangoClient(dataDir);
 
     const cleanup = async () => {
       await client.close();


### PR DESCRIPTION
- MangoDBClient → MangoClient (matches MongoClient)
- MangoDBDb → MangoDb
- MangoDBCollection → MangoCollection
- MangoDBCursor → MangoCursor
- MongoDuplicateKeyError → DuplicateKeyError

This improves the drop-in replacement experience by making class names more consistent with MongoDB driver conventions.