### PR TITLE
chore: add CHANGELOG.md and LICENSE (MAN-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-12-27
+
+### Added
+- Initial release
+- MongoDB-compatible API for file-based storage
+- Query operators: 31/32 supported (all except `$where`)
+- Update operators: 20/20 (100% coverage)
+- Aggregation stages: 29/34 supported
+- Expression operators: 121/127 supported
+- Index types: single, compound, text, TTL, partial, 2d, 2dsphere, hashed, wildcard
+- Geospatial queries with GeoJSON support
+- Text search with weighted indexes
+- Trigonometry expression operators (15 operators)
+- `$jsonSchema` query operator
+- `$merge` aggregation stage
+- Comprehensive documentation

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 J Kershaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Add MIT license file
- Add CHANGELOG.md with initial v0.1.0 release notes

This PR tests the Linear-GitHub integration.

Closes MAN-25

## Test plan
- [x] Files added correctly
- [ ] Verify PR appears in Linear issue MAN-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive changelog documenting version 0.1.0, detailing features including MongoDB-compatible storage, query/update/aggregation operators, index types, geospatial and text search, trigonometric operators, JSON schema validation, and merge functionality.

* **Chores**
  * Added MIT License.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->