### PR TITLE
feat: add in-process mutex to prevent race conditions

### DIFF
--- a/src/mutex.ts
+++ b/src/mutex.ts
@@ -1,0 +1,19 @@
+/**
+ * Simple in-process mutex for serializing async operations.
+ */
+export class Mutex {
+  private queue = Promise.resolve();
+
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    let resolve: () => void;
+    const tail = this.queue;
+    this.queue = new Promise((r) => (resolve = r));
+
+    await tail;
+    try {
+      return await fn();
+    } finally {
+      resolve!();
+    }
+  }
+}

--- a/test/integration/concurrency/mutex.test.ts
+++ b/test/integration/concurrency/mutex.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import {
+  createTestClient,
+  getTestModeName,
+  type TestClient,
+} from '../../test-harness.ts';
+
+describe(`Concurrency Tests (${getTestModeName()})`, () => {
+  let client: TestClient;
+  let cleanup: () => Promise<void>;
+  let dbName: string;
+
+  before(async () => {
+    const result = await createTestClient();
+    client = result.client;
+    cleanup = result.cleanup;
+    dbName = result.dbName;
+    await client.connect();
+  });
+
+  after(async () => {
+    await cleanup();
+  });
+
+  it('should handle concurrent insertOne without data loss', async () => {
+    const collection = client.db(dbName).collection('concurrent_insert');
+    const n = 100;
+
+    const promises = Array.from({ length: n }, (_, i) =>
+      collection.insertOne({ index: i })
+    );
+
+    await Promise.all(promises);
+
+    const count = await collection.countDocuments();
+    assert.strictEqual(count, n, `Expected ${n} documents, got ${count}`);
+  });
+
+  it('should handle concurrent $inc updates correctly', async () => {
+    const collection = client.db(dbName).collection('concurrent_update');
+    await collection.insertOne({ counter: 0 });
+
+    const n = 50;
+    const promises = Array.from({ length: n }, () =>
+      collection.updateOne({}, { $inc: { counter: 1 } })
+    );
+
+    await Promise.all(promises);
+
+    const doc = await collection.findOne({});
+    assert.strictEqual(doc?.counter, n);
+  });
+
+  it('should handle mixed concurrent operations', async () => {
+    const collection = client.db(dbName).collection('concurrent_mixed');
+    await collection.insertMany([{ type: 'a' }, { type: 'b' }]);
+
+    const promises = [
+      collection.insertOne({ type: 'c' }),
+      collection.updateOne({ type: 'a' }, { $set: { updated: true } }),
+      collection.deleteOne({ type: 'b' }),
+      collection.insertOne({ type: 'd' }),
+    ];
+
+    await Promise.all(promises);
+
+    const docs = await collection.find({}).toArray();
+    assert.strictEqual(docs.length, 3); // 2 + 2 inserts - 1 delete
+  });
+});


### PR DESCRIPTION
Add a simple promise-based mutex to serialize concurrent write operations on the same collection, preventing data loss from read-modify-write races.

Changes:
- Add src/mutex.ts with ~10 line Mutex class (no dependencies)
- Wrap all 16 write operations in collection.ts with mutex
- Refactor bulkWrite to use wrapped replaceOne method
- Add concurrency tests demonstrating the fix

Before: 100 concurrent inserts resulted in only 1 document saved
After: All 100 documents are correctly persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reliability by ensuring database operations are properly serialized, preventing potential data corruption during concurrent access.

* **Tests**
  * Added comprehensive concurrency tests to verify data integrity under simultaneous operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->